### PR TITLE
StyledText: Changed span children to be inline

### DIFF
--- a/src/components/StyledText/styledText .scss
+++ b/src/components/StyledText/styledText .scss
@@ -4,8 +4,12 @@
   p {
     color: inherit !important;
   }
-
-  p {
+  * {
+    display: inline;
+  }
+}
+span.styledText {
+  * {
     display: inline;
   }
 }


### PR DESCRIPTION
### StyledText: 
1. Changed the SCSS to have all styledText `span` children to be inline:

This change was made as block elements, such as headings, were being pushed to a new line.