### PR TITLE
Added default prop to ProductCard class name, prevents undefined class

### DIFF
--- a/src/components/ProductCard/index.js
+++ b/src/components/ProductCard/index.js
@@ -21,6 +21,10 @@ const ProductCard = ({
   )
 }
 
+ProductCard.defaultProps = {
+  className: "",
+}
+
 ProductCard.propTypes = {
   actionButton: PropTypes.object,
   // subHeading: PropTypes.object,


### PR DESCRIPTION
If a prop is not supplied to Product Card then it renders the element with an `undefined` class. This is not intended and could potentially end up with a lot of negative side effects where somehow the `undefined` class gets CSS properties, and this then gets applied to different components wherever an `undefined` class gets set.
 
I've added a default prop to the ProductCard that is set to an empty string (`""`), which prevents the `underfined` class for being generated in ProductCard